### PR TITLE
fix(track_a_report_D-4677): copyright text

### DIFF
--- a/src/sass/modules/track-a-report.scss
+++ b/src/sass/modules/track-a-report.scss
@@ -55,13 +55,14 @@
         margin-bottom: 0;
         font-size: x-small;
 
-      @media #{$mobile} {
-        font-size: 0.4rem;      }
-    }
+        > p {
+          color: black;
+          margin-bottom: inherit;
+        }
 
-    .copyright-information > p {
-      color: black;
-      margin-bottom: inherit;
+      @media #{$mobile} {
+        font-size: 0.4rem;
+      }
     }
 }
 

--- a/src/sass/modules/track-a-report.scss
+++ b/src/sass/modules/track-a-report.scss
@@ -49,11 +49,19 @@
     }
 
     .copyright-information {
-        color: $white;
         position: absolute;
         bottom: 0;
+        right: 5px;
         margin-bottom: 0;
         font-size: x-small;
+
+      @media #{$mobile} {
+        font-size: 0.4rem;      }
+    }
+
+    .copyright-information > p {
+      color: black;
+      margin-bottom: inherit;
     }
 }
 


### PR DESCRIPTION
1) Removed white font colour
2) Added > p selector for black font colour, as p tag was inheriting from a higher class
3) Added media query for font size on mobile, as x-small was still too large and wrapping on mobile view
4) Added little extra right spacing for text
5) Allowed the p tag to inherit the copyright div margin, not the generic p tag for this section