### PR TITLE
style(info-list): add decoration to links

### DIFF
--- a/src/sass/modules/information-list.scss
+++ b/src/sass/modules/information-list.scss
@@ -5,6 +5,14 @@
   li {
     margin-left: 0;
 
+    a {
+      text-decoration: underline;
+    
+      &:hover {
+        text-decoration-thickness: 3px;
+      }
+    }
+
     .icon-column {
       @extend .grid-5;
     }


### PR DESCRIPTION
People who are colourblind may be unable to find a link if colour is its only distinguishing feature. Providing another visual cue -such as underlining will also make it easier for non-colourblind people (especially people with low vision) to scan the page.